### PR TITLE
Update hardF5.sh

### DIFF
--- a/scripts/hardF5.sh
+++ b/scripts/hardF5.sh
@@ -66,7 +66,7 @@ tmsh modify /ltm profile client-ssl clientssl-hard options { dont-insert-empty-f
 
 # HTTP Profiles
 tmsh modify /ltm profile http http server-agent-name aws
-tmsh modify /ltm profile http http hsts { mode enabled } 	#Disable for HTTP Virtual Servers (New Child Profile)
+tmsh create /ltm profile http http-hsts hsts { mode enabled } 	#Disable for HTTP Virtual Servers (New Child Profile)
 
 
 # Persistence Profiles


### PR DESCRIPTION
Adding HSTS to default HTTP profile can cause problems with IAPP deployments.